### PR TITLE
Fixed ability to specify sleep in config.yaml

### DIFF
--- a/gendo/bot.py
+++ b/gendo/bot.py
@@ -22,7 +22,7 @@ class Gendo(object):
         self.scheduled_tasks = []
         self.client = SlackClient(
             slack_token or self.settings.get('gendo', {}).get('auth_token'))
-        self.sleep = 0.5 or self.settings.get('gendo', {}).get('sleep')
+        self.sleep = self.settings.get('gendo', {}).get('sleep') or 0.5
 
     @classmethod
     def config_from_yaml(cls, path_to_yaml):


### PR DESCRIPTION
The current code always uses `0.5` even when you specify a different value for sleep in your `config.yaml` file.
