### PR TITLE
fix python3 'pip install' bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from setuptools import setup, find_packages
-from itertools import ifilter
+try:
+    from itertools import ifilter
+except:
+    ifilter = filter
 from os import path
 from ast import parse
 import pip


### PR DESCRIPTION
Installing gendo in Python3 is failed by 'pip install gendo'.
itertools.ifilter is deprecated in Python3.
