### PR TITLE
Decode data about user to utf

### DIFF
--- a/gendo/bot.py
+++ b/gendo/bot.py
@@ -96,7 +96,7 @@ class Gendo(object):
                              channel=channel, text=message)
 
     def get_user_info(self, user_id):
-        user = self.client.api_call('users.info', user=user_id)
+        user = self.client.api_call('users.info', user=user_id).decode('utf-8')
         return json.loads(user)
 
     def get_user_name(self, user_id):


### PR DESCRIPTION
In Python3 you must decode this data as object returns as bytes,
not str. It still works for Python2.
