### PR TITLE
Add channel when asking bot for version info

### DIFF
--- a/gendo/bot.py
+++ b/gendo/bot.py
@@ -74,7 +74,7 @@ class Gendo(object):
         if not message:
             return
         elif message == 'gendo version':
-            self.speak("Gendo v{0}".format(__version__))
+            self.speak("Gendo v{0}".format(__version__), channel)
             return
         for phrase, view_func, options in self.listeners:
             if phrase in message.lower():


### PR DESCRIPTION
'speak' method need to know channel for answer to, so it is nice
to provide it when you want to know bot version.
