### PR TITLE
Remove **options from listen_for method

### DIFF
--- a/gendo/bot.py
+++ b/gendo/bot.py
@@ -31,10 +31,12 @@ class Gendo(object):
             settings = yaml.load(ymlfile)
             return cls(settings=settings)
 
-    def listen_for(self, rule, **options):
+    def listen_for(self, rule):
         def decorator(f):
-            self.add_listener(rule, f, **options)
-            return f
+            def wrapped(**kwargs):
+                self.add_listener(rule, f, **kwargs)
+                return f
+            wrapped()
         return decorator
 
     def cron(self, schedule, **options):

--- a/gendo/bot.py
+++ b/gendo/bot.py
@@ -36,7 +36,7 @@ class Gendo(object):
             def wrapped(**kwargs):
                 self.add_listener(rule, f, **kwargs)
                 return f
-            wrapped()
+            return wrapped()
         return decorator
 
     def cron(self, schedule, **options):


### PR DESCRIPTION
Change signature of 'listen_for' method by deleting **options
signature from it, as it was broken anyway - you had had no
option to run this with additional named options, but it was
needed to have an ability of pushing options of decorated
function. Instead of it some 'academic' code was added - now
'listen_for' method is a decorator factory which returns
decorator that have new function declared inside. It allows to
push named options of decorated function to it and get rid of
wrong signature of factory.
