### PR TITLE
Changing shebangs in executable scripts:

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Installation
 
 .. code:: python
 
-    #!/usr/bin/env/python
+    #!/usr/bin/env python
     # -*- coding: utf-8 -*-
     from gendo import Gendo
     gendo = Gendo("xoxb-1234567890-replace-this-with-token-from-slack")

--- a/gendo.py
+++ b/gendo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import os
 from gendo import Gendo

--- a/gendo/__init__.py
+++ b/gendo/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # flake8: noqa
 __title__ = 'gendo'

--- a/gendo/bot.py
+++ b/gendo/bot.py
@@ -1,6 +1,6 @@
-from __future__ import absolute_import
-#!/usr/bin/env/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import json
 import logging
 import datetime

--- a/gendo/scheduler.py
+++ b/gendo/scheduler.py
@@ -1,6 +1,6 @@
-from __future__ import absolute_import
-#!/usr/bin/env/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import datetime
 from crontab import CronTab
 


### PR DESCRIPTION
- Using /usr/bin/env for all shebang invocations
- Moving shebangs to first line of the script, before any Python code
