### PR TITLE
fix cron bug

### DIFF
--- a/gendo/scheduler.py
+++ b/gendo/scheduler.py
@@ -15,7 +15,7 @@ class Task(object):
     def get_next_run(self, schedule):
         now = datetime.datetime.now()
         entry = CronTab(schedule)
-        delta = datetime.timedelta(0, next(entry))
+        delta = datetime.timedelta(0, entry.next())
         return now + delta
 
     def run(self):


### PR DESCRIPTION
'gendo.cron' generator occurs an Exception.
'next' is CronTab's method.
