### PR TITLE
Adding support for callable rules (worth it?)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,9 +127,33 @@ which is a string of the complete message.
 
 .. code:: python
 
-   @gendo.listen_for('cookies')
+    @gendo.listen_for('cookies')
     def cookies(user, message):
         # do something when someone say's "cookies" here.
+
+
+You can also set more complicated rules with callables, and you can stack them!
+Here's an example.
+
+
+    def nicks_joke_rule(name, message):
+        is_nick = name == 'nficano'
+        is_telling_a_joke = message.lower().count('knock') == 2
+        return is_nick and is_telling_a_joke
+
+
+    def bens_joke_rule(name, message):
+        is_ben = name == 'johnbenjaminlewis'
+        is_telling_a_joke = message.lower().count('knock') == 2
+
+
+    @gendo.listen_for(nicks_joke_rule)
+    @gendo.listen_for(bens_joke_rule)
+    def another_joke(name, message):
+        if name == 'johnbenjaminlewis':
+            return '@johnbenjaminlewis, nice try. But no.'
+        elif name == 'nficano':
+            return "@here Nick's telling a joke! Who's there?!?"
 
 Finally your script needs to sit inside a loop, monitor whats said in a slack
 channel and respond to the messages accordingly. To do this we add the

--- a/gendo/bot.py
+++ b/gendo/bot.py
@@ -41,8 +41,8 @@ class Gendo(object):
         :raises ValueError: If `supplied_rule` is neither a string nor a
                             callable with the appropriate signature.
         """
-        # If basestring, make a simple match callable
-        if isinstance(supplied_rule, basestring):
+        # If string, make a simple match callable
+        if isinstance(supplied_rule, six.string_types):
             return lambda user, message: supplied_rule in message.lower()
 
         if not six.callable(supplied_rule):

--- a/gendo/bot.py
+++ b/gendo/bot.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import
 import json
 import logging
+import inspect
 import datetime
 import os
 import sys
@@ -11,6 +12,7 @@ import time
 from slackclient import SlackClient
 from .scheduler import Task
 from . import __version__
+import six
 import yaml
 
 log = logging.getLogger(__name__)
@@ -31,7 +33,38 @@ class Gendo(object):
             settings = yaml.load(ymlfile)
             return cls(settings=settings)
 
+    def _verify_rule(self, supplied_rule):
+        """Rules must be callable with (user, message) in the signature.
+        Strings are automatically converted to callables that match.
+
+        :returns: Callable rule function with user, message as signature.
+        :raises ValueError: If `supplied_rule` is neither a string nor a
+                            callable with the appropriate signature.
+        """
+        # If basestring, make a simple match callable
+        if isinstance(supplied_rule, basestring):
+            return lambda user, message: supplied_rule in message.lower()
+
+        if not six.callable(supplied_rule):
+            raise ValueError('Bot rules must be callable or strings')
+
+        expected = ('user', 'message')
+        signature = tuple(inspect.getargspec(supplied_rule).args)
+        try:
+            # Support class- and instance-methods where first arg is
+            # something like `self` or `cls`.
+            assert len(signature) in (2, 3)
+            assert expected == signature or expected == signature[-2:]
+        except AssertionError:
+            msg = 'Rule signuture must have only 2 arguments: user, message'
+            raise ValueError(msg)
+
+        return supplied_rule
+
     def listen_for(self, rule, **options):
+        """Decorator for adding a Rule. See guidelines for rules.
+        """
+        rule = self._verify_rule(rule)
         def decorator(f):
             self.add_listener(rule, f, **options)
             return f
@@ -76,8 +109,8 @@ class Gendo(object):
         elif message == 'gendo version':
             self.speak("Gendo v{0}".format(__version__), channel)
             return
-        for phrase, view_func, options in self.listeners:
-            if phrase in message.lower():
+        for rule, view_func, options in self.listeners:
+            if rule(user, message):
                 response = view_func(user, message, **options)
                 if response:
                     if '{user.username}' in response:


### PR DESCRIPTION
This pull request generalizes rules for `gendo.listen_for`. Particularly, rules are now callable functions that return booleans. If a simple string is passed, it is converted into a case-insensitive match function.

Note: this is sort of dubious. The rule gets passed `user` and `message` the same way that the function it decorates does. Essentially, there is little difference in applying the rule in the function body or the rule part itself, other than to have a shorter-running callable for the rule itself.

^^ Clear as mud, right?  See my comments in the code, maybe it will make more sense.
